### PR TITLE
Update plex to respect changes in rust

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -640,7 +640,7 @@ fn parse_parser<'a>(
         },
         |rhs, token| {
             match token {
-                Some(id) => !rhs.act.exclusions.contains(id.as_str()),
+                Some(id) => !rhs.act.exclusions.contains(&id.name.to_string()),
                 None => !rhs.act.exclude_eof,
             }
         },
@@ -650,7 +650,9 @@ fn parse_parser<'a>(
                 LR1Conflict::ReduceReduce { state, token, r1, r2 } => {
                     cx.span_err(sp, &*format!("reduce-reduce conflict:
 state: {}
-token: {}", pretty(&state, "       "), token.map(ast::Ident::as_str).unwrap_or("EOF")));
+token: {}", pretty(&state, "       "),
+            match token { Some(id) => id.name.to_string(),
+                          None     => "EOF".to_string() }));
                     cx.span_note(r1.1.act.span, "conflicting rule");
                     cx.span_note(r2.1.act.span, "conflicting rule");
                     Err(FatalError)
@@ -658,7 +660,9 @@ token: {}", pretty(&state, "       "), token.map(ast::Ident::as_str).unwrap_or("
                 LR1Conflict::ShiftReduce { state, token, rule } => {
                     cx.span_err(rule.1.act.span, &*format!("shift-reduce conflict:
 state: {}
-token: {}", pretty(&state, "       "), token.map(ast::Ident::as_str).unwrap_or("EOF")));
+token: {}", pretty(&state, "       "),
+            match token { Some(id) => id.name.to_string(),
+                          None     => "EOF".to_string() }));
                     Err(FatalError)
                 }
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -226,7 +226,6 @@ where T: Ord + fmt::Debug + fmt::Display,
                         init: Some(quote_expr!(cx, *$stack_id.pop().unwrap().downcast::<$ty>().unwrap())),
                         id: DUMMY_NODE_ID,
                         span: DUMMY_SP,
-                        source: ast::LocalLet,
                     });
                     P(codemap::respan(DUMMY_SP, ast::StmtDecl(P(codemap::respan(DUMMY_SP, ast::DeclLocal(local))), DUMMY_NODE_ID)))
                 }


### PR DESCRIPTION
This pull request fixes two issues that pop up with recent (after 2015-07-25) nightlies of the rust compiler.

The first commit of this pull request updates plex with respect to commit https://github.com/rust-lang/rust/commit/adfdbc4bd75f2581e9ad0151b26fb786b64475f8 which removes the `source` field of `syntax::ast::Local`.

The second commit of this pull request updates plex with respect to commit https://github.com/rust-lang/rust/commit/00a5e66f818ad9d79cc4425f5564c7b07e3213a6 which removes `syntax::ast::Ident::as_str`.