### PR TITLE
Update to rust 1.8.0-nightly (3f4227af1 2016-02-10)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,14 +3,14 @@
 extern crate lalr;
 extern crate regex_dfa;
 extern crate syntax;
-extern crate rustc;
+extern crate rustc_plugin;
 
 pub mod lexer;
 pub mod parser;
 
 use syntax::ext::base;
 use syntax::parse::token;
-use rustc::plugin;
+use rustc_plugin as plugin;
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut plugin::Registry) {


### PR DESCRIPTION
I've updated the code to work with the current nightly build of Rust (commit 3f4227af1, 2016-02-10).

I haven't managed to figure out what one needs to do about the warnings of the form:

    examples/demo.rs:1:1: 1:1 warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    examples/demo.rs:1:1: 1:1 note: for more information, see RFC 218 <https://github.com/rust-lang/rfcs/blob/master/text/0218-empty-struct-with-braces.md>
    examples/demo.rs:1:1: 1:1 warning: `Semi` does not name a tuple variant or a tuple struct, #[warn(match_of_unit_variant_via_paren_dotdot)] on by default
    examples/demo.rs:1 #![feature(plugin)]
                       ^
    examples/demo.rs:138:5: 209:6 note: in this expansion of parser! (defined in examples/demo.rs)