### PR TITLE
eliminate owned_slice

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,6 +1,6 @@
 use syntax::ptr::P;
 use syntax::util::small_vector::SmallVector;
-use syntax::{codemap, ast, owned_slice};
+use syntax::{codemap, ast, ptr};
 use syntax::parse::{self, parser, token, classify, PResult};
 use syntax::ext::base;
 use syntax::ext::build::AstBuilder;
@@ -193,7 +193,7 @@ fn parse_lexer<'a>(cx: &mut base::ExtCtxt<'a>, sp: codemap::Span, args: &[ast::T
                 lifetime: text_lt,
                 bounds: Vec::new(),
             }],
-            ty_params: owned_slice::OwnedSlice::empty(),
+            ty_params: ptr::P::new(),
             where_clause: ast::WhereClause {
                 id: DUMMY_NODE_ID,
                 predicates: Vec::new(),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,7 +3,7 @@ use std::{fmt,cmp};
 use std::fmt::Write;
 use syntax::ptr::P;
 use syntax::util::small_vector::SmallVector;
-use syntax::{ast, owned_slice, codemap};
+use syntax::{ast, ptr, codemap};
 use syntax::parse::{parser, token, classify, PResult};
 //use syntax::parse::attr::ParserAttr;
 use syntax::ext::base;
@@ -131,8 +131,8 @@ where T: Ord + fmt::Debug + fmt::Display,
     ]));
     let generics = ast::Generics {
         lifetimes: vec![],
-        ty_params: owned_slice::OwnedSlice::from_vec(vec![
-            cx.typaram(DUMMY_SP, it_ty_id, owned_slice::OwnedSlice::from_vec(vec![
+        ty_params: ptr::P::from_vec(vec![
+            cx.typaram(DUMMY_SP, it_ty_id, ptr::P::from_vec(vec![
                 cx.typarambound(cx.path_all(DUMMY_SP, true, vec![
                     cx.ident_of("std"),
                     cx.ident_of("iter"),


### PR DESCRIPTION
(libsyntax/)owned_slice had been deprecated since 1.7.0 and finally 9108fb7bae1 (Vadim Petrochenkov) was merged into nightly.