### PR TITLE
Compat with latest nightly

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,4 +1,5 @@
 use syntax::ptr::P;
+use syntax::util::ThinVec;
 use syntax::util::small_vector::SmallVector;
 use syntax::{codemap, ast, ptr};
 use syntax::parse::{self, parser, token, classify, PResult};
@@ -191,6 +192,7 @@ fn parse_lexer<'a>(cx: &mut base::ExtCtxt<'a>, sp: codemap::Span, args: &[TokenT
         ast::Generics {
             span: DUMMY_SP,
             lifetimes: vec![ast::LifetimeDef {
+                attrs: ThinVec::new(),
                 lifetime: text_lt,
                 bounds: Vec::new(),
             }],

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -117,7 +117,7 @@ where T: Ord + fmt::Debug + fmt::Display,
     let generics = ast::Generics {
         lifetimes: vec![],
         ty_params: ptr::P::from_vec(vec![
-            cx.typaram(DUMMY_SP, it_ty_id, ptr::P::from_vec(vec![
+            cx.typaram(DUMMY_SP, it_ty_id, vec![], ptr::P::from_vec(vec![
                 cx.typarambound(cx.path_all(DUMMY_SP, true, vec![
                     cx.ident_of("std"),
                     cx.ident_of("iter"),
@@ -263,7 +263,7 @@ where T: Ord + fmt::Debug + fmt::Display,
             let rspan = result.span;
 
             let tmp = token::gensym_ident("result");
-            reduce_stmts.push(cx.stmt_let_typed(DUMMY_SP, false, tmp, lhs_ty.clone(), result).unwrap());
+            reduce_stmts.push(cx.stmt_let_typed(DUMMY_SP, false, tmp, lhs_ty.clone(), result));
             reduce_stmts.push(quote_stmt!(cx,
                 $stack_id.push(Box::new($tmp) as Box<::std::any::Any>);
             ).unwrap());


### PR DESCRIPTION
Building against `rustc 1.14.0-nightly (098d22845 2016-10-13)`.