### PR TITLE
Hacky unit/tuple variant fix

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,4 +1,3 @@
-#![allow(match_of_unit_variant_via_paren_dotdot)]
 #![feature(plugin)]
 #![plugin(plex)]
 


### PR DESCRIPTION
I don't love this 'solution' at all and feel free to just ditch this, but it's some food for thought, anyway. I couldn't work out a way to include some out-of-band information about the identifier so that we could pick it up in the `to_pat` stage, because all we have there is the table and no way to get back to the specific rule/action, so I just shoved it into the identifier itself.

I _probably_ missed something obvious. I'm also a total noob to Rust, so my style may be grade A Awful — any critique is appreciated, and I also understand if you don't have the time for this. :)

Refs #9.