### PR TITLE
Changes to build on current rust-nightly

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -238,12 +238,11 @@ fn parse_lexer<'a>(cx: &mut base::ExtCtxt<'a>, sp: codemap::Span, args: &[TokenT
         quote_ty!(cx, Option<$ret_ty>),
         ast::Generics {
             span: DUMMY_SP,
-            lifetimes: vec![ast::LifetimeDef {
+            params: vec![ast::GenericParam::Lifetime(ast::LifetimeDef {
                 attrs: ThinVec::new(),
                 lifetime: text_lt,
                 bounds: Vec::new(),
-            }],
-            ty_params: vec![],
+            })],
             where_clause: ast::WhereClause {
                 id: DUMMY_NODE_ID,
                 span: DUMMY_SP,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -46,7 +46,6 @@ pub fn dfa_fn<T>(cx: &base::ExtCtxt, dfa: &Dfa<char, T>, state_enum: Ident, stat
                 pats: vec![pat],
                 guard: None,
                 body: cx.expr_path(state_paths[target as usize].clone()),
-                beginning_vert: None,
             });
         }
         subarms.push(cx.arm(DUMMY_SP, vec![quote_pat!(cx, _)], cx.expr_path(state_paths[tr.default as usize].clone())));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -20,7 +20,7 @@ fn lit_u32(cx: &base::ExtCtxt, val: u32) -> P<ast::Expr> {
     cx.expr_lit(DUMMY_SP, ast::LitKind::Int(val as u128, ast::LitIntType::Unsigned(ast::UintTy::U32)))
 }
 fn lit_usize(cx: &base::ExtCtxt, val: usize) -> P<ast::Expr> {
-    cx.expr_lit(DUMMY_SP, ast::LitKind::Int(val as u128, ast::LitIntType::Unsigned(ast::UintTy::Us)))
+    cx.expr_lit(DUMMY_SP, ast::LitKind::Int(val as u128, ast::LitIntType::Unsigned(ast::UintTy::Usize)))
 }
 fn pat_u32(cx: &base::ExtCtxt, val: u32) -> P<ast::Pat> {
     cx.pat_lit(DUMMY_SP, lit_u32(cx, val))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -152,9 +152,8 @@ where T: Ord + fmt::Debug + fmt::Display,
         span_ty.clone(),
     ]));
     let generics = ast::Generics {
-        lifetimes: vec![],
-        ty_params: vec![
-            cx.typaram(DUMMY_SP, it_ty_id, vec![], vec![
+        params: vec![
+            ast::GenericParam::Type(cx.typaram(DUMMY_SP, it_ty_id, vec![], vec![
                 cx.typarambound(cx.path_all(DUMMY_SP, true, vec![
                     cx.ident_of("std"),
                     cx.ident_of("iter"),
@@ -167,7 +166,7 @@ where T: Ord + fmt::Debug + fmt::Display,
                         span: DUMMY_SP,
                     }
                 ]))
-            ], None)
+            ], None))
         ],
         where_clause: ast::WhereClause {
             id: DUMMY_NODE_ID,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -317,7 +317,7 @@ where T: Ord + fmt::Debug + fmt::Display,
             let tmp = gensym("result");
             let lambda_ty = lhs_ty.clone();
             reduce_stmts.push(cx.stmt_let_typed(DUMMY_SP, false, tmp, lhs_ty.clone(),
-                P(quote_expr!(cx, ( || -> $lambda_ty { $result } )() ).unwrap())));
+                P(quote_expr!(cx, ( || -> $lambda_ty { $result } )() ).into_inner())));
             reduce_stmts.push(quote_stmt!(cx,
                 $stack_id.push(Box::new($tmp) as Box<::std::any::Any>);
             ).unwrap());
@@ -745,7 +745,7 @@ fn parse_parser<'a>(
                 expr = P(quote_expr!(cx, {
                     println!("reduce by {}", $rule_str);
                     $expr
-                }).unwrap());
+                }).into_inner());
             }
 
             (expr, args, act.span)


### PR DESCRIPTION
This is a handful of changes that allow building on rustc 1.25.0-nightly (27a046e93 2018-02-18).

It builds, but I'm not sure how to properly test these changes, so I can't prove they're correct.