### PR TITLE
Use 'proc-macro = true' instead of crate-type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["tokenizer", "scanner", "lexer", "parser", "generator"]
 [lib]
 
 name = "plex"
-crate-type = ["proc-macro"]
+proc-macro = true
 
 [dependencies]
 


### PR DESCRIPTION
See https://github.com/rust-lang/cargo/issues/5310

Both ways of writing this appear to work when compiling `plex` itself; however, `crate-type = ["proc-macro"]` breaks `rustdoc` on downstream crates.  `proc-macro = true` is the syntax used in all documentation I can find of the feature:

* https://doc.rust-lang.org/book/first-edition/procedural-macros.html
* https://doc.rust-lang.org/unstable-book/language-features/proc-macro.html