### PR TITLE
Separate lexer and parser features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,16 @@ keywords = ["tokenizer", "scanner", "lexer", "parser", "generator"]
 name = "plex"
 proc-macro = true
 
+[features]
+
+default = ["lexer", "parser"]
+lexer = ["redfa"]
+parser = ["lalr"]
+
 [dependencies]
 
-lalr = "0.0.2"
-redfa = "0.0.2"
+lalr = { version = "0.0.2", optional = true }
+redfa = { version = "0.0.2", optional = true }
 syn = { version = "0.14.0", features = ["extra-traits", "full"] }
 proc-macro2 = { version = "0.4.3", features = ["nightly"] }
 quote = "0.6.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,25 +3,31 @@
 #![feature(proc_macro_span)]
 #![warn(unused_extern_crates)]
 
+#[cfg(feature = "parser")]
 extern crate lalr;
 extern crate proc_macro2;
 extern crate proc_macro;
 #[macro_use]
 extern crate quote;
+#[cfg(feature = "lexer")]
 extern crate redfa;
 #[macro_use]
 extern crate syn;
 
+#[cfg(feature = "lexer")]
 mod lexer;
+#[cfg(feature = "parser")]
 mod parser;
 
 use proc_macro::TokenStream;
 
+#[cfg(feature = "lexer")]
 #[proc_macro]
 pub fn lexer(tok: TokenStream) -> TokenStream {
     lexer::lexer(tok.into()).into()
 }
 
+#[cfg(feature = "parser")]
 #[proc_macro]
 pub fn parser(tok: TokenStream) -> TokenStream {
     parser::parser(tok.into()).into()


### PR DESCRIPTION
This commit adds two Cargo features, "lexer" and "parser," which as their names suggest allow building plex with both the lexer and parser (this is the default), or alternatively just one of the lexer or parser (this requires setting `default-features = false` in the user's Cargo.toml). Only setting one of the features can reduce dependencies (and build time) on either redfa or lalr if only one of the lexer or parser will be used.

My own motivation for this is that in my own project, I'm using plex for lexing tokens (which is great :)) while also using a custom Pratt-style parser for the expression grammar.