### PR TITLE
Specify type of `stack` variable in generated code for parser

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -228,7 +228,7 @@ where
         }
     }
     stmts.push(quote!(
-        let mut stack = Vec::new();
+        let mut stack: Vec<Box<#any_ty>> = Vec::new();
         let mut span_stack = Vec::new();
         let mut state_stack = Vec::new();
         let mut state: u32 = 0;


### PR DESCRIPTION
This fixes the errors I'm getting on some grammars:

    error[E0282]: type annotations needed for `std::vec::Vec<T>`
      --> src/parser.rs:12:1
       |
    12 | / plex::parser! {
    13 | |     fn parse_(Token, Span);
    14 | |
    15 | |     // combine two spans
    ...  |
    36 | |     }
    37 | | }
       | |_^ consider giving `stack` the explicit type `std::vec::Vec<T>`, where the type parameter `T` is specified
       |
       = note: type must be known at this point
       = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

    error: aborting due to previous error