### PR TITLE
Upgrade to redfa 0.0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ parser = ["lalr"]
 [dependencies]
 
 lalr = { version = "0.0.2", optional = true }
-redfa = { version = "0.0.2", optional = true }
+redfa = { version = "0.0.3", optional = true }
 syn = { version = "2.0", features = ["extra-traits", "full"] }
 proc-macro2 = { version = "1.0" }
 quote = "1.0"


### PR DESCRIPTION
I want to package it for Fedora, but don't want to package old redfa 0.0.2.